### PR TITLE
Atom 1.13 Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "repository": "https://github.com/tyrannicaltoucan/deep-space-syntax",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   }
 }

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,7 +1,6 @@
 // Editor styles (background, gutter, guides)
 
-atom-text-editor,
-:host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,192 +1,192 @@
 // Language syntax highlighting
 
-.comment {
+.syntax--comment {
   color: @gray3;
   font-style: italic;
 
-  .keyword,
-  .keyword.punctuation,
-  .string,
-  .parameter,
-  .type,
-  .markup.link {
+  .syntax--keyword,
+  .syntax--keyword.syntax--punctuation,
+  .syntax--string,
+  .syntax--parameter,
+  .syntax--type,
+  .syntax--markup.syntax--link {
     color: @gray4;
   }
 }
 
-.entity {
-  &.name.type {
+.syntax--entity {
+  &.syntax--name.syntax--type {
     color: @orange;
   }
 }
 
-.keyword {
+.syntax--keyword {
   color: @blue;
 
-  &.operator {
+  &.syntax--operator {
     color: @syntax-text-color;
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @cyan;
   }
 
-  &.other {
+  &.syntax--other {
     color: @red;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @blue;
 }
 
-.constant {
+.syntax--constant {
   color: @red;
 }
 
-.variable {
+.syntax--variable {
   color: @purple;
 
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: @pink;
   }
 
-  &.parameter {
+  &.syntax--parameter {
     color: @syntax-text-color;
   }
 }
 
-.string {
+.syntax--string {
   color: @green;
 
-  &.regexp {
+  &.syntax--regexp {
     color: @yellow;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @orange;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @red;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.string {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--string {
       color: @green;
     }
 
-    &.tag {
+    &.syntax--tag {
       color: @blue;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @blue;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @orange;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @purple;
       font-style: italic;
     }
   }
 
-  &.separator {
+  &.syntax--separator {
     color: @syntax-text-color;
   }
 
-  &.section {
-    &.embedded {
+  &.syntax--section {
+    &.syntax--embedded {
       color: @pink;
     }
 
-    &.method,
-    &.class,
-    &.inner-class {
+    &.syntax--method,
+    &.syntax--class,
+    &.syntax--inner-class {
       color: @syntax-text-color;
     }
   }
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color: @orange;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @cyan;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @yellow;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @yellow;
   }
 
-  &.name.class,
-  &.name.type.class {
+  &.syntax--name.syntax--class,
+  &.syntax--name.syntax--type.syntax--class {
     color: @orange;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @blue;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @purple;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @yellow;
 
-    &.id {
+    &.syntax--id {
       color: @cyan;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @orange;
 
-    &.body {
+    &.syntax--body {
       color: @syntax-text-color;
     }
   }
 
-  &.require {
+  &.syntax--require {
     color: @blue;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @gray2;
     color: @syntax-text-color;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-text-color;
 }
 
-.invalid {
-  &.deprecated {
+.syntax--invalid {
+  &.syntax--deprecated {
     color: @syntax-background-color !important;
     background-color: @yellow !important;
   }
 
-  &.illegal {
+  &.syntax--illegal {
     color: @syntax-background-color !important;
     background-color: @red !important;
   }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,11 +1,11 @@
-.source.css {
-  .entity.other.attribute-name {
-    &.pseudo-class,
-    &.pseudo-element {
+.syntax--source.syntax--css {
+  .syntax--entity.syntax--other.syntax--attribute-name {
+    &.syntax--pseudo-class,
+    &.syntax--pseudo-element {
       color: @orange;
     }
 
-    &.parent-selector {
+    &.syntax--parent-selector {
       color: @blue;
     }
   }

--- a/styles/languages/go.less
+++ b/styles/languages/go.less
@@ -1,5 +1,5 @@
-.source.go {
-  .storage.type.string {
+.syntax--source.syntax--go {
+  .syntax--storage.syntax--type.syntax--string {
     color: @blue;
   }
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,11 +1,11 @@
-.source.java {
-  .storage {
-    &.modifier.package,
-    &.modifier.import {
+.syntax--source.syntax--java {
+  .syntax--storage {
+    &.syntax--modifier.syntax--package,
+    &.syntax--modifier.syntax--import {
       color: @green;
     }
 
-    &.type.annotation {
+    &.syntax--type.syntax--annotation {
       color: @cyan;
     }
   }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,13 +1,13 @@
-.source.coffee,
-.source.js {
-  .keyword.operator {
-    &.delete,
-    &.in,
-    &.of,
-    &.instanceof,
-    &.new,
-    &.typeof,
-    &.void {
+.syntax--source.syntax--coffee,
+.syntax--source.syntax--js {
+  .syntax--keyword.syntax--operator {
+    &.syntax--delete,
+    &.syntax--in,
+    &.syntax--of,
+    &.syntax--instanceof,
+    &.syntax--new,
+    &.syntax--typeof,
+    &.syntax--void {
       color: @blue;
     }
   }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,20 +1,20 @@
-.source.json {
-  .meta.structure.dictionary.json {
-    & > .string.quoted.json {
-      & > .punctuation.string {
+.syntax--source.syntax--json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+    & > .syntax--string.syntax--quoted.syntax--json {
+      & > .syntax--punctuation.syntax--string {
         color: @blue;
       }
       color: @blue;
     }
   }
 
-  .meta.structure.dictionary.json, .meta.structure.array.json {
-    & > .value.json > .string.quoted.json,
-    & > .value.json > .string.quoted.json > .punctuation {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
       color: @green;
     }
 
-    & > .constant.language.json {
+    & > .syntax--constant.syntax--language.syntax--json {
       color: @purple;
     }
   }

--- a/styles/languages/markdown.less
+++ b/styles/languages/markdown.less
@@ -1,53 +1,53 @@
-.source.gfm {
-  .link .entity {
+.syntax--source.syntax--gfm {
+  .syntax--link .syntax--entity {
     color: @pink;
   }
 
-  .variable.ordered,
-  .variable.unordered {
+  .syntax--variable.syntax--ordered,
+  .syntax--variable.syntax--unordered {
     color: @purple;
   }
 }
 
-.markup {
-  &.heading {
+.syntax--markup {
+  &.syntax--heading {
     color: @blue;
   }
 
-  &.strike {
+  &.syntax--strike {
     color: @red;
     text-decoration: line-through;
   }
 
-  &.bold {
+  &.syntax--bold {
     color: @yellow;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @yellow;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @red;
   }
 
-  &.inserted,
-  &.quote {
+  &.syntax--inserted,
+  &.syntax--quote {
     color: @green;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @green;
     font-style: italic;
   }
 
-  &.code,
-  &.raw {
+  &.syntax--code,
+  &.syntax--raw {
     color: @cyan;
   }
 
-  &.link {
+  &.syntax--link {
     color: @purple;
   }
 }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,5 +1,5 @@
-.source.python {
-  .keyword.operator.logical.python {
+.syntax--source.syntax--python {
+  .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
       color: @blue;
     }
   }


### PR DESCRIPTION
* Removes use of `:host`
* Prepends `syntax--` to css classes
* Bumps the atom engine per [blog](http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html)